### PR TITLE
using uri module instead of curl cmd + route var fixes

### DIFF
--- a/installation/playbooks/roles/che/tasks/main.yaml
+++ b/installation/playbooks/roles/che/tasks/main.yaml
@@ -1,17 +1,25 @@
 ---
 - name: Get SSO token
-  shell: "curl --insecure -X POST 'https://{{launcher_sso_route}}/auth/realms/launcher_realm/protocol/openid-connect/token' \
-  -H 'Content-Type: application/x-www-form-urlencoded' -d 'username={{ che_launcher_sso_username }}' -d 'password={{ che_launcher_sso_password }}' -d 'grant_type=password' -d 'client_id={{che_keycloak_client_id}}'"
-  register: token_text    
+  uri:
+    url: "{{ che_keycloak_route }}/auth/realms/{{ che_keycloak_realm }}/protocol/openid-connect/token"
+    method: POST
+    body_format: form-urlencoded
+    body:
+      username: "{{ che_launcher_sso_username }}"
+      password: "{{ che_launcher_sso_password }}"
+      grant_type: password
+      client_id: "{{ che_keycloak_client_id }}"
+    validate_certs: no
+  register: token_text
 
-- set_fact: TKN={{ (token_text.stdout | from_json).access_token }}
+- set_fact:
+    TKN: "{{token_text.json.access_token }}"
 
 - debug: var=TKN
 
-# TODO: Make the protocol a var
 - name: Check if Che IDE is deployed
   uri: 
-    url: https://{{che_route}}/api/stack
+    url: "{{che_route}}/api/stack"
     validate_certs: false
     method: GET
     headers:
@@ -25,7 +33,7 @@
 - name: Update custom stack to Che
   tags: install_custom_stack
   uri: 
-    url: https://{{che_route}}/api/stack
+    url: "{{che_route}}/api/stack"
     validate_certs: false
     method: POST
     return_content: yes
@@ -170,7 +178,7 @@
 
 - name: Give stack view/read permissions to all other users
   uri:
-    url: https://{{che_route}}/api/permissions
+    url: "{{che_route}}/api/permissions"
     validate_certs: false
     method: POST
     return_content: yes


### PR DESCRIPTION
Removing the curl command to use the `uri`ansible module + removed the https protocol from all url fields since those are already being used in the generated inventory file.

NOTE: currently the inventory is being generated using `che_keycloak_client_id="che-public"` where it should be `che_keycloak_client_id="che-client"` which is an installer issue.