### PR TITLE
Update README to use OS neutral commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,8 @@ To run an example customisation you need an exiting OpenShift cluster with integ
 
 Next you need to get the available inventory file from the manifest secret
 
-```
-(mac osx)
-
-oc get secret inventory -n webapp --template '{{index .data "generated_inventory"}}'  | base64 -D > inventory
-```
-
-```
-(Linux)
-
-oc get secret inventory -n webapp --template '{{index .data "generated_inventory"}}'  | base64 -d > inventory
+```sh
+oc get secret inventory -n webapp --template '{{index .data "generated_inventory"|base64decode}}' > inventory
 ```
 
 You should also be logged into the cluster as an admin user.


### PR DESCRIPTION
Minor contribution to the README: replace two commands (one for Linux, one for MacOS) with one that works for both. 